### PR TITLE
feat: Add .claude/launch.json preview config to each template

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -104,6 +104,11 @@ jobs:
             exit 1
           fi
 
+          if [ ! -f "$PROJECT_NAME/.claude/launch.json" ]; then
+            echo "Error: .claude/launch.json was not created in $PROJECT_NAME"
+            exit 1
+          fi
+
           cd "$PROJECT_NAME"
 
           echo "Installing dependencies..."

--- a/lib/constants/renameFiles.js
+++ b/lib/constants/renameFiles.js
@@ -6,6 +6,7 @@ export const renameFiles = {
 	'_env': '.env',
 	'_env.example': '.env.example',
 	_aiignore: '.aiignore',
+	_claude: '.claude',
 	_github: '.github',
 	_gitignore: '.gitignore',
 	_nvmrc: '.nvmrc',

--- a/lib/init.js
+++ b/lib/init.js
@@ -76,7 +76,7 @@ export async function init() {
 		// Write out the contents based on all prior steps.
 		const cwd = process.cwd();
 		const root = path.join(cwd, targetDir);
-		scaffoldProject(root, projectName, packageName, template, envVars);
+		scaffoldProject(root, projectName, packageName, template, envVars, pkgManager);
 
 		// Log out the next steps.
 		installAndOptionallyStart(root, pkgManager, immediate, args.skipInstall, selectedSkills, selectedAgents);

--- a/lib/init.test.js
+++ b/lib/init.test.js
@@ -117,9 +117,14 @@ describe('init.js', () => {
 			expect(installAndOptionallyStart).toHaveBeenCalled();
 		});
 
-		expect(scaffoldProject).toHaveBeenCalledWith(expect.stringContaining('my-dir'), 'my-project', 'my-pkg', 'vanilla', {
-			target: 't',
-		});
+		expect(scaffoldProject).toHaveBeenCalledWith(
+			expect.stringContaining('my-dir'),
+			'my-project',
+			'my-pkg',
+			'vanilla',
+			{ target: 't' },
+			expect.any(String),
+		);
 		expect(installAndOptionallyStart).toHaveBeenCalledWith(
 			expect.stringContaining('my-dir'),
 			expect.any(String),

--- a/lib/steps/scaffoldProject.js
+++ b/lib/steps/scaffoldProject.js
@@ -12,8 +12,9 @@ import { crawlTemplateDir } from '../fs/crawlTemplateDir.js';
  * @param {string} packageName - The name for the package.json.
  * @param {string} template - The template name to use.
  * @param {import('./getEnvVars.js').EnvVars} [envVars] - Environment variables to substitute.
+ * @param {string} [pkgManager] - The package manager that invoked us (e.g. npm, pnpm, yarn, bun). Defaults to npm.
  */
-export function scaffoldProject(root, projectName, packageName, template, envVars) {
+export function scaffoldProject(root, projectName, packageName, template, envVars, pkgManager) {
 	fs.mkdirSync(root, { recursive: true });
 	prompts.log.step(`Scaffolding project in ${root}...`);
 
@@ -21,6 +22,7 @@ export function scaffoldProject(root, projectName, packageName, template, envVar
 		'your-project-name-here': projectName || 'your-project-name-here',
 		'your-package-name-here': packageName || 'your-package-name-here',
 		'your-fabric.harper.fast-cluster-url-here': envVars?.target || 'your-fabric.harper.fast-cluster-url-here',
+		'your-package-manager-here': pkgManager || 'npm',
 		'\n\t"repository": "github:HarperFast/create-harper",': '',
 	};
 

--- a/lib/steps/scaffoldProject.test.js
+++ b/lib/steps/scaffoldProject.test.js
@@ -22,7 +22,7 @@ describe('scaffoldProject', () => {
 			target: 'testtarget',
 		};
 
-		scaffoldProject(root, projectName, packageName, template, envVars);
+		scaffoldProject(root, projectName, packageName, template, envVars, 'pnpm');
 
 		expect(fs.mkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
 		expect(prompts.log.step).toHaveBeenCalledWith(expect.stringContaining('Scaffolding project'));
@@ -33,6 +33,7 @@ describe('scaffoldProject', () => {
 				'your-project-name-here': projectName,
 				'your-package-name-here': packageName,
 				'your-fabric.harper.fast-cluster-url-here': envVars.target,
+				'your-package-manager-here': 'pnpm',
 			}),
 		);
 	});
@@ -49,6 +50,7 @@ describe('scaffoldProject', () => {
 				'your-project-name-here': 'your-project-name-here',
 				'your-package-name-here': 'your-package-name-here',
 				'your-fabric.harper.fast-cluster-url-here': 'your-fabric.harper.fast-cluster-url-here',
+				'your-package-manager-here': 'npm',
 			}),
 		);
 	});

--- a/template-early-hints/_claude/launch.json
+++ b/template-early-hints/_claude/launch.json
@@ -1,0 +1,11 @@
+{
+	"version": "0.0.1",
+	"configurations": [
+		{
+			"name": "harper",
+			"runtimeExecutable": "npm",
+			"runtimeArgs": ["run", "dev"],
+			"port": 9926
+		}
+	]
+}

--- a/template-early-hints/_claude/launch.json
+++ b/template-early-hints/_claude/launch.json
@@ -3,7 +3,7 @@
 	"configurations": [
 		{
 			"name": "harper",
-			"runtimeExecutable": "npm",
+			"runtimeExecutable": "your-package-manager-here",
 			"runtimeArgs": ["run", "dev"],
 			"port": 9926
 		}

--- a/template-react-ssr/_claude/launch.json
+++ b/template-react-ssr/_claude/launch.json
@@ -1,0 +1,11 @@
+{
+	"version": "0.0.1",
+	"configurations": [
+		{
+			"name": "harper",
+			"runtimeExecutable": "npm",
+			"runtimeArgs": ["run", "dev"],
+			"port": 9926
+		}
+	]
+}

--- a/template-react-ssr/_claude/launch.json
+++ b/template-react-ssr/_claude/launch.json
@@ -3,7 +3,7 @@
 	"configurations": [
 		{
 			"name": "harper",
-			"runtimeExecutable": "npm",
+			"runtimeExecutable": "your-package-manager-here",
 			"runtimeArgs": ["run", "dev"],
 			"port": 9926
 		}

--- a/template-react-ts-ssr/_claude/launch.json
+++ b/template-react-ts-ssr/_claude/launch.json
@@ -1,0 +1,11 @@
+{
+	"version": "0.0.1",
+	"configurations": [
+		{
+			"name": "harper",
+			"runtimeExecutable": "npm",
+			"runtimeArgs": ["run", "dev"],
+			"port": 9926
+		}
+	]
+}

--- a/template-react-ts-ssr/_claude/launch.json
+++ b/template-react-ts-ssr/_claude/launch.json
@@ -3,7 +3,7 @@
 	"configurations": [
 		{
 			"name": "harper",
-			"runtimeExecutable": "npm",
+			"runtimeExecutable": "your-package-manager-here",
 			"runtimeArgs": ["run", "dev"],
 			"port": 9926
 		}

--- a/template-react-ts/_claude/launch.json
+++ b/template-react-ts/_claude/launch.json
@@ -1,0 +1,11 @@
+{
+	"version": "0.0.1",
+	"configurations": [
+		{
+			"name": "harper",
+			"runtimeExecutable": "npm",
+			"runtimeArgs": ["run", "dev"],
+			"port": 9926
+		}
+	]
+}

--- a/template-react-ts/_claude/launch.json
+++ b/template-react-ts/_claude/launch.json
@@ -3,7 +3,7 @@
 	"configurations": [
 		{
 			"name": "harper",
-			"runtimeExecutable": "npm",
+			"runtimeExecutable": "your-package-manager-here",
 			"runtimeArgs": ["run", "dev"],
 			"port": 9926
 		}

--- a/template-react/_claude/launch.json
+++ b/template-react/_claude/launch.json
@@ -1,0 +1,11 @@
+{
+	"version": "0.0.1",
+	"configurations": [
+		{
+			"name": "harper",
+			"runtimeExecutable": "npm",
+			"runtimeArgs": ["run", "dev"],
+			"port": 9926
+		}
+	]
+}

--- a/template-react/_claude/launch.json
+++ b/template-react/_claude/launch.json
@@ -3,7 +3,7 @@
 	"configurations": [
 		{
 			"name": "harper",
-			"runtimeExecutable": "npm",
+			"runtimeExecutable": "your-package-manager-here",
 			"runtimeArgs": ["run", "dev"],
 			"port": 9926
 		}

--- a/template-vanilla-ts/_claude/launch.json
+++ b/template-vanilla-ts/_claude/launch.json
@@ -1,0 +1,11 @@
+{
+	"version": "0.0.1",
+	"configurations": [
+		{
+			"name": "harper",
+			"runtimeExecutable": "npm",
+			"runtimeArgs": ["run", "dev"],
+			"port": 9926
+		}
+	]
+}

--- a/template-vanilla-ts/_claude/launch.json
+++ b/template-vanilla-ts/_claude/launch.json
@@ -3,7 +3,7 @@
 	"configurations": [
 		{
 			"name": "harper",
-			"runtimeExecutable": "npm",
+			"runtimeExecutable": "your-package-manager-here",
 			"runtimeArgs": ["run", "dev"],
 			"port": 9926
 		}

--- a/template-vanilla/_claude/launch.json
+++ b/template-vanilla/_claude/launch.json
@@ -1,0 +1,11 @@
+{
+	"version": "0.0.1",
+	"configurations": [
+		{
+			"name": "harper",
+			"runtimeExecutable": "npm",
+			"runtimeArgs": ["run", "dev"],
+			"port": 9926
+		}
+	]
+}

--- a/template-vanilla/_claude/launch.json
+++ b/template-vanilla/_claude/launch.json
@@ -3,7 +3,7 @@
 	"configurations": [
 		{
 			"name": "harper",
-			"runtimeExecutable": "npm",
+			"runtimeExecutable": "your-package-manager-here",
 			"runtimeArgs": ["run", "dev"],
 			"port": 9926
 		}

--- a/template-vue-ssr/_claude/launch.json
+++ b/template-vue-ssr/_claude/launch.json
@@ -1,0 +1,11 @@
+{
+	"version": "0.0.1",
+	"configurations": [
+		{
+			"name": "harper",
+			"runtimeExecutable": "npm",
+			"runtimeArgs": ["run", "dev"],
+			"port": 9926
+		}
+	]
+}

--- a/template-vue-ssr/_claude/launch.json
+++ b/template-vue-ssr/_claude/launch.json
@@ -3,7 +3,7 @@
 	"configurations": [
 		{
 			"name": "harper",
-			"runtimeExecutable": "npm",
+			"runtimeExecutable": "your-package-manager-here",
 			"runtimeArgs": ["run", "dev"],
 			"port": 9926
 		}

--- a/template-vue-ts-ssr/_claude/launch.json
+++ b/template-vue-ts-ssr/_claude/launch.json
@@ -1,0 +1,11 @@
+{
+	"version": "0.0.1",
+	"configurations": [
+		{
+			"name": "harper",
+			"runtimeExecutable": "npm",
+			"runtimeArgs": ["run", "dev"],
+			"port": 9926
+		}
+	]
+}

--- a/template-vue-ts-ssr/_claude/launch.json
+++ b/template-vue-ts-ssr/_claude/launch.json
@@ -3,7 +3,7 @@
 	"configurations": [
 		{
 			"name": "harper",
-			"runtimeExecutable": "npm",
+			"runtimeExecutable": "your-package-manager-here",
 			"runtimeArgs": ["run", "dev"],
 			"port": 9926
 		}

--- a/template-vue-ts/_claude/launch.json
+++ b/template-vue-ts/_claude/launch.json
@@ -1,0 +1,11 @@
+{
+	"version": "0.0.1",
+	"configurations": [
+		{
+			"name": "harper",
+			"runtimeExecutable": "npm",
+			"runtimeArgs": ["run", "dev"],
+			"port": 9926
+		}
+	]
+}

--- a/template-vue-ts/_claude/launch.json
+++ b/template-vue-ts/_claude/launch.json
@@ -3,7 +3,7 @@
 	"configurations": [
 		{
 			"name": "harper",
-			"runtimeExecutable": "npm",
+			"runtimeExecutable": "your-package-manager-here",
 			"runtimeArgs": ["run", "dev"],
 			"port": 9926
 		}

--- a/template-vue/_claude/launch.json
+++ b/template-vue/_claude/launch.json
@@ -1,0 +1,11 @@
+{
+	"version": "0.0.1",
+	"configurations": [
+		{
+			"name": "harper",
+			"runtimeExecutable": "npm",
+			"runtimeArgs": ["run", "dev"],
+			"port": 9926
+		}
+	]
+}

--- a/template-vue/_claude/launch.json
+++ b/template-vue/_claude/launch.json
@@ -3,7 +3,7 @@
 	"configurations": [
 		{
 			"name": "harper",
-			"runtimeExecutable": "npm",
+			"runtimeExecutable": "your-package-manager-here",
 			"runtimeArgs": ["run", "dev"],
 			"port": 9926
 		}

--- a/templates-shared/all/_claude/launch.json
+++ b/templates-shared/all/_claude/launch.json
@@ -1,0 +1,11 @@
+{
+	"version": "0.0.1",
+	"configurations": [
+		{
+			"name": "harper",
+			"runtimeExecutable": "npm",
+			"runtimeArgs": ["run", "dev"],
+			"port": 9926
+		}
+	]
+}

--- a/templates-shared/all/_claude/launch.json
+++ b/templates-shared/all/_claude/launch.json
@@ -3,7 +3,7 @@
 	"configurations": [
 		{
 			"name": "harper",
-			"runtimeExecutable": "npm",
+			"runtimeExecutable": "your-package-manager-here",
 			"runtimeArgs": ["run", "dev"],
 			"port": 9926
 		}

--- a/templates-studio/buildStudioTemplates.js
+++ b/templates-studio/buildStudioTemplates.js
@@ -21,7 +21,11 @@ import { run } from '../lib/run.js';
 			toTemplate,
 			// Studio apps run deployed on Harper Fabric (no local `npm run dev`), so skip the
 			// `.claude/launch.json` preview config that only applies to local development.
-			(srcFile) => !srcFile.includes('_env') && !srcFile.includes('_claude'),
+			// Match on the basename so a clone path containing `_env`/`_claude` doesn't skip everything.
+			(srcFile) => {
+				const filename = path.basename(srcFile);
+				return !filename.startsWith('_env') && filename !== '_claude';
+			},
 			(sourceContent, targetPath) => {
 				if (targetPath.endsWith('/package.json')) {
 					return sourceContent

--- a/templates-studio/buildStudioTemplates.js
+++ b/templates-studio/buildStudioTemplates.js
@@ -19,7 +19,9 @@ import { run } from '../lib/run.js';
 		copyDir(
 			fromTemplate,
 			toTemplate,
-			(srcFile) => !srcFile.includes('_env'),
+			// Studio apps run deployed on Harper Fabric (no local `npm run dev`), so skip the
+			// `.claude/launch.json` preview config that only applies to local development.
+			(srcFile) => !srcFile.includes('_env') && !srcFile.includes('_claude'),
 			(sourceContent, targetPath) => {
 				if (targetPath.endsWith('/package.json')) {
 					return sourceContent


### PR DESCRIPTION
## What

Adds a Claude Code **preview launch config** (`.claude/launch.json`) to every scaffolded Harper project. With this in place, Claude Code (and the Claude preview tooling) can start the project's dev server directly instead of falling back to a bare `Bash` invocation.

Each generated config is:

```json
{
	"version": "0.0.1",
	"configurations": [
		{
			"name": "harper",
			"runtimeExecutable": "npm",
			"runtimeArgs": ["run", "dev"],
			"port": 9926
		}
	]
}
```

`npm run dev` maps to `harper dev .` in every template, and the dev server is served on `http://localhost:9926` (the URL the template READMEs already point users to).

## How

- **Source of truth:** `templates-shared/all/_claude/launch.json`, propagated into all 11 templates via `applySharedTemplates.js` (same pattern as `_nvmrc`, `graphql.config.yml`, etc.).
- **Rename on scaffold:** registered `_claude` → `.claude` in `lib/constants/renameFiles.js` so it lands as `.claude/launch.json` in the generated project.
- **Studio templates excluded:** `buildStudioTemplates.js` now skips `_claude`. Studio apps run *deployed* on Harper Fabric and have empty `scripts`, so a local `npm run dev` preview doesn't apply there.
- **Verification:** the integration workflow now asserts `.claude/launch.json` exists in the scaffolded project.

## Templates covered

`early-hints`, `react`, `react-ts`, `react-ssr`, `react-ts-ssr`, `vanilla`, `vanilla-ts`, `vue`, `vue-ts`, `vue-ssr`, `vue-ts-ssr`

## Testing

- `npm run format:check`, `npm run lint:check`, `npm test` (201 passing) all green.
- Manually scaffolded `react-ts` to a temp dir and confirmed `_claude/launch.json` is renamed to `.claude/launch.json` with the expected contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)