### PR TITLE
docs: show how to read Harper data from the React SSR entry

### DIFF
--- a/template-react-ssr/src/entry-server.jsx
+++ b/template-react-ssr/src/entry-server.jsx
@@ -3,8 +3,25 @@ import { StrictMode } from 'react';
 import { renderToString } from 'react-dom/server';
 
 /**
- * Server render entry. The Vite Harper plugin calls this for HTML navigations and injects the
- * returned markup into the `<!--ssr-outlet-->` placeholder in index.html.
+ * Server render entry. The Vite Harper plugin calls this (awaiting it) for HTML navigations and
+ * injects the returned markup into the `<!--ssr-outlet-->` placeholder in index.html.
+ *
+ * To render with data already in place (no client-side fetch), read from Harper right here. The
+ * `tables` registry is the same live, process-wide object available everywhere in Harper — the SSR
+ * entry can reach it via `import { tables } from 'harper'` because Harper symlinks
+ * `node_modules/harper` to the running install (and `vite.config.js` keeps `harper` external). Make
+ * `render` async and query a table, e.g.:
+ *
+ *     import { tables } from 'harper';
+ *
+ *     export async function render(url) {
+ *       const product = await tables.Product.get(idFromUrl(url));
+ *       return renderToString(
+ *         <StrictMode>
+ *           <App product={product} />
+ *         </StrictMode>,
+ *       );
+ *     }
  *
  * @param {string} _url The request URL — use it to drive routing/data loading per request.
  * @returns {string}

--- a/template-react-ssr/src/entry-server.jsx
+++ b/template-react-ssr/src/entry-server.jsx
@@ -14,6 +14,7 @@ import { renderToString } from 'react-dom/server';
  *
  *     import { tables } from 'harper';
  *
+ *     // The template's App takes no props — update App.jsx to accept `product`.
  *     export async function render(url) {
  *       const product = await tables.Product.get(idFromUrl(url));
  *       return renderToString(

--- a/template-react-ssr/vite.config.js
+++ b/template-react-ssr/vite.config.js
@@ -12,6 +12,13 @@ export default defineConfig({
 			'@': path.resolve(import.meta.dirname, './src'),
 		},
 	},
+	ssr: {
+		// Keep `harper` external so the SSR entry resolves it to Harper's running runtime instead of
+		// bundling it. `node_modules/harper` is symlinked to the running install, and symlinked deps
+		// aren't reliably auto-externalized for SSR — this is what lets `import { tables } from 'harper'`
+		// in entry-server read live data. See src/entry-server.jsx.
+		external: ['harper'],
+	},
 	build: {
 		outDir: 'dist',
 		emptyOutDir: true,

--- a/template-react-ts-ssr/src/entry-server.tsx
+++ b/template-react-ts-ssr/src/entry-server.tsx
@@ -3,8 +3,25 @@ import { StrictMode } from 'react';
 import { renderToString } from 'react-dom/server';
 
 /**
- * Server render entry. The Vite Harper plugin calls this for HTML navigations and injects the
- * returned markup into the `<!--ssr-outlet-->` placeholder in index.html.
+ * Server render entry. The Vite Harper plugin calls this (awaiting it) for HTML navigations and
+ * injects the returned markup into the `<!--ssr-outlet-->` placeholder in index.html.
+ *
+ * To render with data already in place (no client-side fetch), read from Harper right here. The
+ * `tables` registry is the same live, process-wide object available everywhere in Harper — the SSR
+ * entry can reach it via `import { tables } from 'harper'` because Harper symlinks
+ * `node_modules/harper` to the running install (and `vite.config.ts` keeps `harper` external). Make
+ * `render` async and query a table, e.g.:
+ *
+ *     import { tables } from 'harper';
+ *
+ *     export async function render(url: string): Promise<string> {
+ *       const product = await tables.Product.get(idFromUrl(url));
+ *       return renderToString(
+ *         <StrictMode>
+ *           <App product={product} />
+ *         </StrictMode>,
+ *       );
+ *     }
  *
  * @param _url The request URL — use it to drive routing/data loading per request.
  */

--- a/template-react-ts-ssr/src/entry-server.tsx
+++ b/template-react-ts-ssr/src/entry-server.tsx
@@ -14,6 +14,7 @@ import { renderToString } from 'react-dom/server';
  *
  *     import { tables } from 'harper';
  *
+ *     // The template's App takes no props — update App.tsx to accept `product`.
  *     export async function render(url: string): Promise<string> {
  *       const product = await tables.Product.get(idFromUrl(url));
  *       return renderToString(

--- a/template-react-ts-ssr/vite.config.ts
+++ b/template-react-ts-ssr/vite.config.ts
@@ -12,6 +12,13 @@ export default defineConfig({
 			'@': path.resolve(import.meta.dirname, './src'),
 		},
 	},
+	ssr: {
+		// Keep `harper` external so the SSR entry resolves it to Harper's running runtime instead of
+		// bundling it. `node_modules/harper` is symlinked to the running install, and symlinked deps
+		// aren't reliably auto-externalized for SSR — this is what lets `import { tables } from 'harper'`
+		// in entry-server read live data. See src/entry-server.tsx.
+		external: ['harper'],
+	},
 	build: {
 		outDir: 'dist',
 		emptyOutDir: true,


### PR DESCRIPTION
## Why

The React SSR templates ship an `entry-server` whose comment says to use the request URL *"to drive routing/data loading per request"* — but gives **no example of how**. With empty `schemas/`/`resources/` and no data-flow example, a developer reaching the Vite-loaded SSR entry has nothing to go on, and can reasonably (but wrongly) conclude they can't access Harper data there. That leads to workarounds like fetching the app's own REST API over loopback, or assuming the SSR entry doesn't get Harper's globals.

In reality, `tables`/`databases` are live **process-wide** objects, and `node_modules/harper` is symlinked to the running install — so `import { tables } from 'harper'` works in the SSR entry.

## What

Applied to both `template-react-ssr` and `template-react-ts-ssr`:

- **`entry-server.{jsx,tsx}`** — expanded the doc comment to show the native pattern: make `render` async and `import { tables } from 'harper'` to query a table, rendering with data already in place (no client fetch).
- **`vite.config.{js,ts}`** — added `ssr: { external: ['harper'] }` with an explanatory comment. Symlinked deps aren't reliably auto-externalized for SSR, so this is what makes `import { tables } from 'harper'` resolve to the running runtime instead of being bundled.

Both changes are additive (comment + config); the default scaffold still builds and runs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)