### PR TITLE
fix: static notFound catch-all made REST resources unreachable in SPA templates

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -139,4 +139,15 @@ jobs:
             ${{ matrix.pkg-manager }} run build
           fi
 
+          # Boot the generated app under a real Harper instance and verify both the REST
+          # resources and the frontend are reachable (guards against the static handler
+          # swallowing REST GETs). Once per template — the package manager doesn't matter here.
+          if [ "${{ matrix.pkg-manager }}" = "npm" ]; then
+            echo "Installing Harper..."
+            npm install --global harper
+
+            echo "Running runtime smoke test..."
+            node "$REPO_PATH/template.tests/runtimeSmoke.js" .
+          fi
+
           echo "Integration test passed for ${{ matrix.pkg-manager }} with ${{ matrix.template }}!"

--- a/template-react-ts/config.yaml
+++ b/template-react-ts/config.yaml
@@ -33,11 +33,11 @@ jsResource:
   files: 'src/**/*'
   output: 'dist'
 
-# Serves the built frontend from Vite's output directory. `notFound` + `fallthrough: false` makes
-# client-side routing work (unmatched routes return index.html); the REST routes above take precedence.
+# Serves the built frontend from Vite's output directory. Requests that don't match a file fall
+# through to the REST resources above. If you add client-side routing, use hash-based routing
+# (e.g. React Router's `createHashRouter`): every page loads from `/`, so deep links work and
+# index.html stays cacheable at a single URL. Do not add a `notFound` + `fallthrough: false`
+# fallback here — the static handler runs before the REST handler, so it would swallow GET
+# requests to your resources.
 static:
   files: 'dist/**'
-  notFound:
-    file: 'index.html'
-    statusCode: 200
-  fallthrough: false

--- a/template-react/config.yaml
+++ b/template-react/config.yaml
@@ -32,11 +32,11 @@ jsResource:
   files: 'src/**/*'
   output: 'dist'
 
-# Serves the built frontend from Vite's output directory. `notFound` + `fallthrough: false` makes
-# client-side routing work (unmatched routes return index.html); the REST routes above take precedence.
+# Serves the built frontend from Vite's output directory. Requests that don't match a file fall
+# through to the REST resources above. If you add client-side routing, use hash-based routing
+# (e.g. React Router's `createHashRouter`): every page loads from `/`, so deep links work and
+# index.html stays cacheable at a single URL. Do not add a `notFound` + `fallthrough: false`
+# fallback here — the static handler runs before the REST handler, so it would swallow GET
+# requests to your resources.
 static:
   files: 'dist/**'
-  notFound:
-    file: 'index.html'
-    statusCode: 200
-  fallthrough: false

--- a/template-vue-ts/config.yaml
+++ b/template-vue-ts/config.yaml
@@ -33,11 +33,11 @@ jsResource:
   files: 'src/**/*'
   output: 'dist'
 
-# Serves the built frontend from Vite's output directory. `notFound` + `fallthrough: false` makes
-# client-side routing work (unmatched routes return index.html); the REST routes above take precedence.
+# Serves the built frontend from Vite's output directory. Requests that don't match a file fall
+# through to the REST resources above. If you add client-side routing, use hash-based routing
+# (e.g. Vue Router's `createWebHashHistory`): every page loads from `/`, so deep links work and
+# index.html stays cacheable at a single URL. Do not add a `notFound` + `fallthrough: false`
+# fallback here — the static handler runs before the REST handler, so it would swallow GET
+# requests to your resources.
 static:
   files: 'dist/**'
-  notFound:
-    file: 'index.html'
-    statusCode: 200
-  fallthrough: false

--- a/template-vue/config.yaml
+++ b/template-vue/config.yaml
@@ -32,11 +32,11 @@ jsResource:
   files: 'src/**/*'
   output: 'dist'
 
-# Serves the built frontend from Vite's output directory. `notFound` + `fallthrough: false` makes
-# client-side routing work (unmatched routes return index.html); the REST routes above take precedence.
+# Serves the built frontend from Vite's output directory. Requests that don't match a file fall
+# through to the REST resources above. If you add client-side routing, use hash-based routing
+# (e.g. Vue Router's `createWebHashHistory`): every page loads from `/`, so deep links work and
+# index.html stays cacheable at a single URL. Do not add a `notFound` + `fallthrough: false`
+# fallback here — the static handler runs before the REST handler, so it would swallow GET
+# requests to your resources.
 static:
   files: 'dist/**'
-  notFound:
-    file: 'index.html'
-    statusCode: 200
-  fallthrough: false

--- a/template.tests/runtimeSmoke.js
+++ b/template.tests/runtimeSmoke.js
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * Runtime smoke test for a generated template application.
+ *
+ * Boots the app under a real Harper instance (isolated root, throwaway admin user) and verifies
+ * the HTTP surface every template must provide:
+ *
+ *   1. REST resources are reachable over GET — a `resources/` class must answer with JSON.
+ *      This is the regression check for the static `notFound`/`fallthrough: false` catch-all,
+ *      which ran before the REST handler and answered resource GETs with index.html.
+ *   2. The frontend is served — `GET /` returns the app's HTML.
+ *
+ * Usage: node template.tests/runtimeSmoke.js <app-dir>
+ *
+ * The app must already be installed (and built, for templates with a build step). Requires the
+ * `harper` CLI on PATH (or set HARPER_BIN). POSIX only. Ports override via SMOKE_HTTP_PORT /
+ * SMOKE_OPS_PORT.
+ */
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const appDir = process.argv[2] && path.resolve(process.argv[2]);
+if (!appDir || !fs.existsSync(path.join(appDir, 'config.yaml'))) {
+	console.error('Usage: node template.tests/runtimeSmoke.js <app-dir> (must contain a config.yaml)');
+	process.exit(2);
+}
+
+const httpPort = Number(process.env.SMOKE_HTTP_PORT ?? 19926);
+const opsPort = Number(process.env.SMOKE_OPS_PORT ?? 19925);
+const baseUrl = `http://127.0.0.1:${httpPort}`;
+const credentials = `Basic ${Buffer.from('smoke-admin:smoke-password').toString('base64')}`;
+
+// Harper's operations server listens on a unix domain socket inside ROOTPATH, and socket paths
+// are limited to ~104 characters on macOS — so keep the scratch root short and in /tmp.
+const scratchDir = fs.mkdtempSync('/tmp/harper-smoke-');
+const rootPath = path.join(scratchDir, 'hdb');
+const homeDir = path.join(scratchDir, 'home');
+fs.mkdirSync(rootPath);
+fs.mkdirSync(homeDir);
+
+// The REST resource the test queries. Written into the app like a user would add one; the
+// extension must match the template's jsResource glob (`resources/*.ts` in TS templates).
+const isTypeScript = fs.readFileSync(path.join(appDir, 'config.yaml'), 'utf-8').includes('resources/*.ts');
+const resourcePath = path.join(appDir, 'resources', `smokeTestResource.${isTypeScript ? 'ts' : 'js'}`);
+fs.writeFileSync(
+	resourcePath,
+	`export class SmokeTestResource extends Resource {
+	allowRead() {
+		return true;
+	}
+	async get() {
+		return { smoke: 'ok' };
+	}
+}
+`,
+);
+
+const harperBin = process.env.HARPER_BIN ?? 'harper';
+console.log(`Starting ${harperBin} run ${appDir} (root: ${rootPath}, port: ${httpPort})...`);
+const harper = spawn(harperBin, ['run', appDir], {
+	env: {
+		...process.env,
+		// HOME controls where Harper looks for the boot-properties file of an existing
+		// installation; pointing it at a scratch dir guarantees an isolated, fresh install.
+		HOME: homeDir,
+		TC_AGREEMENT: 'yes',
+		HDB_ADMIN_USERNAME: 'smoke-admin',
+		HDB_ADMIN_PASSWORD: 'smoke-password',
+		ROOTPATH: rootPath,
+		HTTP_PORT: String(httpPort),
+		OPERATIONSAPI_NETWORK_PORT: String(opsPort),
+	},
+	// Own process group so cleanup can kill Harper's worker threads/children along with it.
+	detached: true,
+	stdio: ['ignore', 'pipe', 'pipe'],
+});
+
+let harperOutput = '';
+harper.stdout.on('data', (chunk) => (harperOutput += chunk));
+harper.stderr.on('data', (chunk) => (harperOutput += chunk));
+let harperExited = false;
+harper.on('exit', () => (harperExited = true));
+
+function cleanup() {
+	try {
+		process.kill(-harper.pid, 'SIGTERM');
+	} catch {}
+	try {
+		fs.rmSync(scratchDir, { recursive: true, force: true });
+	} catch {}
+	try {
+		fs.rmSync(resourcePath, { force: true });
+	} catch {}
+}
+
+async function waitForServer(timeoutMs = 180_000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (harperExited) {
+			throw new Error(`Harper exited before the HTTP server came up. Output:\n${harperOutput.slice(-4000)}`);
+		}
+		try {
+			await fetch(baseUrl, { signal: AbortSignal.timeout(2000) });
+			return;
+		} catch {
+			await new Promise((resolve) => setTimeout(resolve, 1000));
+		}
+	}
+	throw new Error(`Harper HTTP server did not come up within ${timeoutMs}ms. Output:\n${harperOutput.slice(-4000)}`);
+}
+
+const failures = [];
+
+async function check(name, requestPath, assert) {
+	const response = await fetch(baseUrl + requestPath, {
+		headers: { Authorization: credentials },
+		signal: AbortSignal.timeout(10_000),
+	});
+	const body = await response.text();
+	const problem = assert(response, body);
+	if (problem) {
+		failures.push(
+			`${name}: ${problem}\n  GET ${requestPath} -> ${response.status} ${
+				response.headers.get('content-type')
+			}\n  body: ${body.slice(0, 200)}`,
+		);
+		console.error(`✗ ${name}`);
+	} else {
+		console.log(`✓ ${name}`);
+	}
+}
+
+try {
+	await waitForServer();
+
+	// The regression check: a GET for an exported resource must reach the REST handler and
+	// return its JSON — not be swallowed by the static handler and answered with index.html.
+	await check('REST resource answers GET with JSON', '/SmokeTestResource/', (response, body) => {
+		if (!response.ok) { return `expected 200, got ${response.status}`; }
+		if (!(response.headers.get('content-type') ?? '').includes('application/json')) {
+			return 'expected an application/json response (static handler likely intercepted the request)';
+		}
+		try {
+			if (JSON.parse(body).smoke !== 'ok') { return 'unexpected response body'; }
+		} catch {
+			return 'response body is not JSON';
+		}
+		return null;
+	});
+
+	await check('frontend index is served at /', '/', (response, body) => {
+		if (!response.ok) { return `expected 200, got ${response.status}`; }
+		if (!(response.headers.get('content-type') ?? '').includes('text/html')) {
+			return 'expected a text/html response';
+		}
+		if (!body.toLowerCase().includes('<html')) { return 'response body does not look like an HTML document'; }
+		return null;
+	});
+} catch (error) {
+	failures.push(String(error?.message ?? error));
+} finally {
+	cleanup();
+}
+
+if (failures.length > 0) {
+	console.error(`\nRuntime smoke test FAILED for ${appDir}:\n\n${failures.join('\n\n')}`);
+	process.exit(1);
+}
+console.log(`\nRuntime smoke test passed for ${appDir}.`);
+process.exit(0);

--- a/template.tests/runtimeSmoke.js
+++ b/template.tests/runtimeSmoke.js
@@ -43,6 +43,7 @@ fs.mkdirSync(homeDir);
 // extension must match the template's jsResource glob (`resources/*.ts` in TS templates).
 const isTypeScript = fs.readFileSync(path.join(appDir, 'config.yaml'), 'utf-8').includes('resources/*.ts');
 const resourcePath = path.join(appDir, 'resources', `smokeTestResource.${isTypeScript ? 'ts' : 'js'}`);
+fs.mkdirSync(path.dirname(resourcePath), { recursive: true });
 fs.writeFileSync(
 	resourcePath,
 	`export class SmokeTestResource extends Resource {
@@ -81,10 +82,18 @@ harper.stdout.on('data', (chunk) => (harperOutput += chunk));
 harper.stderr.on('data', (chunk) => (harperOutput += chunk));
 let harperExited = false;
 harper.on('exit', () => (harperExited = true));
+// Without an 'error' listener a failed spawn (e.g. harper not on PATH) is an unhandled
+// exception that skips cleanup entirely.
+harper.on('error', (error) => {
+	harperOutput += `\nFailed to spawn ${harperBin}: ${error.message}\n`;
+	harperExited = true;
+});
 
 function cleanup() {
 	try {
-		process.kill(-harper.pid, 'SIGTERM');
+		if (harper.pid) {
+			process.kill(-harper.pid, 'SIGTERM');
+		}
 	} catch {}
 	try {
 		fs.rmSync(scratchDir, { recursive: true, force: true });
@@ -93,6 +102,17 @@ function cleanup() {
 		fs.rmSync(resourcePath, { force: true });
 	} catch {}
 }
+
+// Harper runs in its own process group (detached), so it outlives this process unless an
+// interrupted run (Ctrl+C, CI cancellation) kills it explicitly.
+process.on('SIGINT', () => {
+	cleanup();
+	process.exit(130);
+});
+process.on('SIGTERM', () => {
+	cleanup();
+	process.exit(143);
+});
 
 async function waitForServer(timeoutMs = 180_000) {
 	const deadline = Date.now() + timeoutMs;
@@ -113,18 +133,25 @@ async function waitForServer(timeoutMs = 180_000) {
 const failures = [];
 
 async function check(name, requestPath, assert) {
-	const response = await fetch(baseUrl + requestPath, {
-		headers: { Authorization: credentials },
-		signal: AbortSignal.timeout(10_000),
-	});
-	const body = await response.text();
-	const problem = assert(response, body);
+	let problem;
+	try {
+		const response = await fetch(baseUrl + requestPath, {
+			headers: { Authorization: credentials },
+			signal: AbortSignal.timeout(10_000),
+		});
+		const body = await response.text();
+		problem = assert(response, body);
+		if (problem) {
+			problem += `\n  GET ${requestPath} -> ${response.status} ${response.headers.get('content-type')}\n  body: ${
+				body.slice(0, 200)
+			}`;
+		}
+	} catch (error) {
+		// A request-level failure shouldn't abort the remaining checks.
+		problem = `GET ${requestPath} failed: ${error.message}`;
+	}
 	if (problem) {
-		failures.push(
-			`${name}: ${problem}\n  GET ${requestPath} -> ${response.status} ${
-				response.headers.get('content-type')
-			}\n  body: ${body.slice(0, 200)}`,
-		);
+		failures.push(`${name}: ${problem}`);
 		console.error(`✗ ${name}`);
 	} else {
 		console.log(`✓ ${name}`);

--- a/template.tests/staticConfig.test.js
+++ b/template.tests/staticConfig.test.js
@@ -1,0 +1,36 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+const root = path.resolve(import.meta.dirname, '..');
+
+// Every template directory on disk with a config.yaml, whether or not it is in the published catalog.
+const templateDirs = fs.readdirSync(root)
+	.filter((name) => name.startsWith('template-') && fs.existsSync(path.join(root, name, 'config.yaml')));
+
+/**
+ * Harper's `static` handler runs before authentication and the REST handler in the HTTP
+ * middleware chain (`runFirst: true` on Harper 5.0.x, `before: 'authentication'` on 5.1+).
+ * A `notFound` catch-all combined with `fallthrough: false` therefore answers every GET —
+ * including requests for the application's exported resources — with the fallback file,
+ * making the REST API unreachable over GET. Templates must serve real files only and let
+ * misses fall through; client-side routing should be hash-based so every page loads from `/`.
+ */
+describe('template static config does not black-hole REST GETs', () => {
+	test('finds template configs to check', () => {
+		expect(templateDirs.length).toBeGreaterThan(0);
+	});
+
+	for (const dir of templateDirs) {
+		test(`${dir} static handler lets unmatched requests fall through`, () => {
+			const config = fs.readFileSync(path.join(root, dir, 'config.yaml'), 'utf-8');
+			const withoutComments = config
+				.split('\n')
+				.filter((line) => !line.trim().startsWith('#'))
+				.join('\n');
+
+			expect(withoutComments).not.toMatch(/fallthrough:\s*false/);
+			expect(withoutComments).not.toMatch(/notFound:/);
+		});
+	}
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -10,6 +10,7 @@ export default defineConfig({
 		},
 		include: [
 			'lib/**/*.test.js',
+			'template.tests/staticConfig.test.js',
 		],
 	},
 });


### PR DESCRIPTION
## Problem

The four SPA templates (`react`, `react-ts`, `vue`, `vue-ts`) configured the static handler with:

```yaml
static:
  files: 'dist/**'
  notFound:
    file: 'index.html'
    statusCode: 200
  fallthrough: false
```

Harper's static handler runs **before** authentication and the REST handler (`runFirst: true` on Harper 5.0.x, `before: 'authentication'` on 5.1+), so this catch-all answered **every** GET — including requests for exported resources — with index.html. The application's REST API was unreachable over GET. Reproduced against a real Harper 5.1.12 instance: `GET /Greeting/` for an exported resource returned `200 text/html` (index.html) instead of the resource's JSON.

The old config comment claimed "the REST routes above take precedence" — the opposite of what actually happens.

## Why not just re-order the static handler?

Harper 5.1+ has an undocumented `before` option on static, and `before: false` empirically drops the pre-auth hoist so static lands after REST (verified working end-to-end on 5.1.12). But on Harper **5.0.x** static is hard-coded `runFirst: true` with no knob at all, so config-level re-ordering silently does nothing there. Since templates run against whatever Harper version users have, the shipped fix can't rely on it. (A companion Harper PR adds first-class `after` ordering + a config warning.)

## Fix

Drop `notFound` + `fallthrough: false` from the four SPA templates. Unmatched requests now fall through to REST, and the config comment steers users toward hash-based routing (`createHashRouter` / `createWebHashHistory`) — deep links always load from `/`, and index.html stays cacheable at a single URL. Neither template ships a client-side router, so nothing user-visible changes.

The SSR and vanilla templates were already correct and are untouched. The gitignored studio templates regenerate from these sources, so they inherit the fix at publish time.

## Regression guards

- **`template.tests/staticConfig.test.js`** (wired into `npm test`): sweeps every `template-*/config.yaml` (comments stripped) and fails if the `notFound`/`fallthrough: false` catch-all pattern reappears. Verified red on the old config, green on the new.
- **`template.tests/runtimeSmoke.js`** (wired into the integration workflow, once per template): boots the generated app under a real, fully isolated Harper instance (fresh `HOME`/`ROOTPATH`, throwaway admin), injects a REST resource matching the template's `resources/*.js|ts` glob, and asserts the resource answers GET with JSON while `/` serves the frontend HTML. Verified green on fixed `react`, `react-ts`, and `vanilla`, and red on the broken config (fails with "static handler likely intercepted the request", showing the HTML body).

## Testing

- `npm test` — 213 passing (including the 12 new invariant tests)
- `npm run lint:check`, `npm run format:check` — clean
- Runtime smoke test run locally against scaffolds of `react`, `react-ts`, and `vanilla` on Harper 5.1.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)