### PR TITLE
fix(templates): drop removed baseUrl option from TS tsconfigs

### DIFF
--- a/template-react-ts-ssr/tsconfig.json
+++ b/template-react-ts-ssr/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true,
 		"jsx": "react-jsx",
-		"baseUrl": ".",
 		"paths": {
 			"@/*": [
 				"./src/*"

--- a/template-react-ts/tsconfig.json
+++ b/template-react-ts/tsconfig.json
@@ -8,7 +8,6 @@
 		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true,
 		"jsx": "react-jsx",
-		"baseUrl": ".",
 		"paths": {
 			"@/*": [
 				"./src/*"

--- a/template-vue-ts-ssr/tsconfig.json
+++ b/template-vue-ts-ssr/tsconfig.json
@@ -7,7 +7,6 @@
 		"types": ["vite/client"],
 		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true,
-		"baseUrl": ".",
 		"paths": {
 			"@/*": [
 				"./src/*"

--- a/template-vue-ts/tsconfig.json
+++ b/template-vue-ts/tsconfig.json
@@ -7,7 +7,6 @@
 		"types": ["vite/client"],
 		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true,
-		"baseUrl": ".",
 		"paths": {
 			"@/*": [
 				"./src/*"


### PR DESCRIPTION
## What

Removes the `baseUrl` compiler option from all four TypeScript template `tsconfig.json` files:

- `template-react-ts`
- `template-react-ts-ssr`
- `template-vue-ts`
- `template-vue-ts-ssr`

## Why

`baseUrl` is **deprecated in TypeScript 6** (emits `TS5101`, which fails `tsc` unless `ignoreDeprecations` is set) and **removed in TypeScript 7** (`TS5102: Option 'baseUrl' has been removed`). As shipped, `tsc --noEmit` on a generated project already errors out today — it just isn't caught by CI because no template runs `tsc`/`vue-tsc` (build is `vite build`, tests use Node's native type-stripping, lint is non-type-aware `@eslint/js`).

Since TS 5.0, the `paths` mapping (`@/*` → `./src/*`) resolves relative to `tsconfig.json` **without** `baseUrl`, and the Vite `@` alias is defined independently in `vite.config.ts` (`path.resolve(import.meta.dirname, './src')`). So dropping `baseUrl` keeps `@/` imports resolving in both the type checker and the bundler.

## Verification

On generated react-ts and vue-ts projects:
- `tsc --noEmit` → exit 0 (previously errored on `baseUrl`), `@/` imports resolve
- `vite build` → succeeds
- Repo suite: `dprint check` clean, all 213 unit tests pass

## Relationship to #114

This is independent of the TypeScript 7 bump in #114 — it fixes an already-broken `tsc` experience on `main` regardless of TS version. #114 (TS7) is being held as draft because `vue-tsc` is not yet compatible with the native TS7 compiler; see the tracking notes on that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)