### PR TITLE
ci(integration): pin pnpm to 11.11.0 to fix self-installer regression

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -23,7 +23,13 @@ jobs:
         if: matrix.pkg-manager == 'pnpm'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11
+          # Pin an exact pnpm version, not a floating major. The action is SHA-pinned,
+          # but `version: 11` makes it resolve to the newest 11.x at run time and
+          # self-install it — so the pnpm binary itself was unpinned. pnpm 11.12.0
+          # regressed that self-installer (lockfile integrity handling), breaking CI.
+          # Pinning keeps CI reproducible and avoids auto-pulling an unvetted build.
+          # Bump deliberately once a known-good newer version is verified.
+          version: 11.11.0
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Problem

Every `Generate * with pnpm` integration job has been failing across PRs since 2026-07-13. The failure happens in the `Setup pnpm` step's self-installer, **before any template is generated**:

```
Switching pnpm from v11.7.0 to v11.12.0...
[ERROR] Cannot use 'in' operator to search for 'integrity' in undefined
    at createFullPkgId (.../pnpm.mjs)
    at lockfileToDepGraph (.../pnpm.mjs)
    ...
    at installPnpmToGlobalDir (.../pnpm.mjs)
##[error]Something went wrong, self-installer exits with code 1
```

## Root cause

`pnpm/action-setup` is SHA-pinned (`@0ebf471…` = v6.0.9) — but the `version: 11` input is a **floating major**. The action resolves it to the newest 11.x at run time and self-installs that. So the action was pinned while the pnpm binary was not.

**pnpm 11.12.0** (published 2026-07-11) regressed its self-installer's lockfile handling — the [11.12.0 release](https://github.com/pnpm/pnpm/releases/tag/v11.12.0) shipped lockfile/resolution changes, and the crash is in `lockfileToDepGraph`/`createFullPkgId` reading a lockfile entry with a missing integrity field (cf. pnpm [#12001](https://github.com/pnpm/pnpm/issues/12001), [#12136](https://github.com/pnpm/pnpm/issues/12136), advisory [CVE-2026-50021](https://advisories.gitlab.com/npm/pnpm/CVE-2026-50021/)). Main was last green on the pnpm jobs on 2026-07-06 using 11.10.0; the break appeared as soon as `version: 11` started resolving to 11.12.0.

## Fix

Pin `version:` to an exact, known-good release — **11.11.0**, the last one before the 11.12.0 lockfile changes. This:

- unblocks the pnpm integration jobs immediately,
- makes CI **reproducible** instead of silently tracking whatever 11.x is newest, and
- closes the **supply-chain gap** of auto-pulling an unvetted pnpm build into CI on every run — a self-updating package manager in CI is exactly the kind of thing worth pinning.

The pin is annotated in the workflow so it's bumped deliberately (once a fixed newer pnpm is verified) rather than reverted to a floating major.

## Validation

This PR's own `Generate * with pnpm` jobs exercise the pinned version (the `pull_request` workflow uses the PR branch's workflow file), so green pnpm checks here confirm the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)