### PR TITLE
chore(renovate): group pre-1.0 dprint/oxfmt bumps with non-major deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,7 +36,6 @@
 			"groupSlug": "all-minor-patch",
 			"matchPackageNames": ["dprint", "oxfmt"],
 			"matchCurrentVersion": "< 1.0.0",
-			"matchUpdateTypes": ["minor", "patch"],
 			"automerge": true
 		}
 	]

--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,15 @@
 			],
 			"matchCurrentVersion": "!/^0/",
 			"automerge": true
+		},
+		{
+			"description": "Treat pre-1.0 dprint/oxfmt (stable formatters) as non-major so bumps group with other deps; regroups normally once they reach 1.0.0+.",
+			"groupName": "all non-major dependencies",
+			"groupSlug": "all-minor-patch",
+			"matchPackageNames": ["dprint", "oxfmt"],
+			"matchCurrentVersion": "< 1.0.0",
+			"matchUpdateTypes": ["minor", "patch"],
+			"automerge": true
 		}
 	]
 }


### PR DESCRIPTION
## What

Treat pre-1.0 `dprint`/`oxfmt` bumps as **non-major**, so they group into the existing "all non-major dependencies" PR instead of opening a separate PR every release.

## Why

Under caret semantics `^0.58.0` doesn't satisfy `0.59.0`, so Renovate splits every `0.x` minor bump of these formatters into its own PR (e.g. the standalone oxfmt/dprint PRs this week). They're stable in practice and any breakage surfaces immediately in the formatter tooling — no need for individual review.

## How

Adds a `packageRules` entry mirroring the existing non-major group, scoped to `dprint`/`oxfmt` while `matchCurrentVersion: "< 1.0.0"`. Once either reaches 1.0.0 the rule stops matching and they return to the normal major cadence (separate PRs) automatically. Validated with `renovate-config-validator`.

Companion PRs applied to the other repos carrying these tools (schema-codegen, agent-tools, create-harper, studio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)